### PR TITLE
Add stylesheet preloading support with async option

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -17,7 +17,7 @@ module.exports = async function module(moduleOptions) {
             href: options.materialDesignIconsHRef
         }
 
-        if (async) {
+        if (options.async) {
             attributes.rel = 'preload';
             attributes.as = 'style';
             attributes.onload = 'this.rel=\'stylesheet\'';

--- a/lib/module.js
+++ b/lib/module.js
@@ -3,7 +3,8 @@ const { resolve } = require('path')
 const defaults = {
     css: true,
     materialDesignIcons: true,
-    materialDesignIconsHRef: 'https://cdn.jsdelivr.net/npm/@mdi/font@5.8.55/css/materialdesignicons.min.css'
+    materialDesignIconsHRef: 'https://cdn.jsdelivr.net/npm/@mdi/font@5.8.55/css/materialdesignicons.min.css',
+    async: false
 }
 
 module.exports = async function module(moduleOptions) {
@@ -11,11 +12,20 @@ module.exports = async function module(moduleOptions) {
 
     // Add Material Design Icons font
     if (options.materialDesignIcons !== false) {
-        this.options.head.link.push({
-            rel: 'stylesheet',
+        const attributes = {
             type: 'text/css',
             href: options.materialDesignIconsHRef
-        })
+        }
+
+        if (async) {
+            attributes.rel = 'preload';
+            attributes.as = 'style';
+            attributes.onload = 'this.rel=\'stylesheet\'';
+        } else {
+            attributes.rel = 'stylesheet';
+        }
+
+        this.options.head.link.push(attributes)
     }
 
     // Add css

--- a/lib/module.js
+++ b/lib/module.js
@@ -18,11 +18,11 @@ module.exports = async function module(moduleOptions) {
         }
 
         if (options.async) {
-            attributes.rel = 'preload';
-            attributes.as = 'style';
-            attributes.onload = 'this.rel=\'stylesheet\'';
+            attributes.rel = 'preload'
+            attributes.as = 'style'
+            attributes.onload = 'this.rel=\'stylesheet\''
         } else {
-            attributes.rel = 'stylesheet';
+            attributes.rel = 'stylesheet'
         }
 
         this.options.head.link.push(attributes)

--- a/lib/module.js
+++ b/lib/module.js
@@ -4,7 +4,7 @@ const defaults = {
     css: true,
     materialDesignIcons: true,
     materialDesignIconsHRef: 'https://cdn.jsdelivr.net/npm/@mdi/font@5.8.55/css/materialdesignicons.min.css',
-    async: false
+    async: true
 }
 
 module.exports = async function module(moduleOptions) {


### PR DESCRIPTION
- Support loading the stylesheet asynchronously with `rel="preload"`.
- Add an `async` option.

Loading the icons stylesheet asynchronously would prevent issues if the CDN is not available.

https://www.filamentgroup.com/lab/async-css.html#a-modern-approach
https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content
